### PR TITLE
Add support for the Sass Deprecations API (fixes #671)

### DIFF
--- a/sass-embedded-host/src/main/java/de/larsgrefer/sass/embedded/SassCompiler.java
+++ b/sass-embedded-host/src/main/java/de/larsgrefer/sass/embedded/SassCompiler.java
@@ -125,6 +125,26 @@ public class SassCompiler implements Closeable {
     @Setter
     private boolean silent = false;
 
+    /**
+     * This option tells Sass to treat a particular type of deprecation warning as an error.
+     * @see #addFatalDeprecation(String)
+     */
+    private final List<String> fatalDeprecations = new ArrayList<>();
+
+    /**
+     * This option tells Sass to opt in to a future type of deprecation warning early, emitting warnings even though
+     * the deprecation is not yet active.
+     * @see #addFutureDeprecation(String)
+     */
+    private final List<String> futureDeprecations = new ArrayList<>();
+
+    /**
+     * This option tells Sass to silence a particular type of deprecation warning if you wish to temporarily ignore
+     * the deprecation.
+     * @see #addSilenceDeprecation(String)
+     */
+    private final List<String> silenceDeprecations = new ArrayList<>();
+
     private final CompilerConnection connection;
 
     private final Random compileRequestIds = new Random();
@@ -147,6 +167,43 @@ public class SassCompiler implements Closeable {
 
     public OutboundMessage.VersionResponse getVersion() throws IOException {
         return exec(inboundMessage(VersionRequest.getDefaultInstance())).getVersionResponse();
+    }
+
+    /**
+     * Adds a deprecation type to the list of fatal deprecations. Sass will treat a warning for this type of deprecation
+     * as an error.
+     * <p>
+     * For a list of deprecation types, see the
+     * <a href="https://sass-lang.com/documentation/cli/dart-sass/#fatal-deprecation">Sass documentation</a>.
+     * @param deprecationId a deprecation ID
+     */
+    public void addFatalDeprecation(@NonNull String deprecationId) {
+        fatalDeprecations.add(deprecationId);
+    }
+
+    /**
+     * Adds a deprecation type to the list of future deprecations. Sass will opt in to this type of deprecation
+     * warning early, emitting warnings even though the deprecation is not yet active. This can be combined with
+     * {@link #addFatalDeprecation(String)} to emit errors instead of warnings for a future deprecation.
+     * <p>
+     * For a list of deprecation types, see the
+     * <a href="https://sass-lang.com/documentation/cli/dart-sass/#fatal-deprecation">Sass documentation</a>.
+     * @param deprecationId a deprecation ID
+     */
+    public void addFutureDeprecation(@NonNull String deprecationId) {
+        futureDeprecations.add(deprecationId);
+    }
+
+    /**
+     * Adds a deprecation type to the list of silenced deprecations. Sass will silence warnings for this type of
+     * deprecation.
+     * <p>
+     * For a list of deprecation types, see the
+     * <a href="https://sass-lang.com/documentation/cli/dart-sass/#fatal-deprecation">Sass documentation</a>.
+     * @param deprecationId a deprecation ID
+     */
+    public void addSilenceDeprecation(@NonNull String deprecationId) {
+        silenceDeprecations.add(deprecationId);
     }
 
     public void registerFunction(@NonNull HostFunction sassFunction) {
@@ -199,6 +256,9 @@ public class SassCompiler implements Closeable {
         builder.setSourceMapIncludeSources(sourceMapIncludeSources);
         builder.setCharset(emitCharset);
         builder.setSilent(silent);
+        builder.addAllFatalDeprecation(fatalDeprecations);
+        builder.addAllFutureDeprecation(futureDeprecations);
+        builder.addAllSilenceDeprecation(silenceDeprecations);
 
         return builder;
     }

--- a/sass-embedded-host/src/test/java/de/larsgrefer/sass/embedded/SassCompilerTest.java
+++ b/sass-embedded-host/src/test/java/de/larsgrefer/sass/embedded/SassCompilerTest.java
@@ -1,9 +1,6 @@
 package de.larsgrefer.sass.embedded;
 
-import com.sass_lang.embedded_protocol.InboundMessage;
-import com.sass_lang.embedded_protocol.OutboundMessage;
-import com.sass_lang.embedded_protocol.OutputStyle;
-import com.sass_lang.embedded_protocol.Value;
+import com.sass_lang.embedded_protocol.*;
 import de.larsgrefer.sass.embedded.functions.HostFunction;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
@@ -14,11 +11,13 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static de.larsgrefer.sass.embedded.BootstrapUtil.getBoostrapVersion;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SassCompilerTest {
@@ -154,4 +153,38 @@ class SassCompilerTest {
         System.out.println(compileSuccess1.getSourceMap());
     }
 
+    @Test
+    void silenceDeprecations() {
+        @Language("SCSS") String scss = ".foo { color: adjust-color(#000000, $red: 255); }";
+        
+        InboundMessage.CompileRequest.StringInput string = InboundMessage.CompileRequest.StringInput.newBuilder()
+                .setSource(scss)
+                .build();
+
+        List<OutboundMessage.LogEventOrBuilder> logEvents = new ArrayList<>();
+        sassCompiler.setLoggingHandler(logEvents::add);
+        
+        assertDoesNotThrow(() -> sassCompiler.compileString(string, OutputStyle.EXPANDED));
+        assertThat(logEvents).anyMatch(event -> event.getType() == LogEventType.DEPRECATION_WARNING);
+        
+        logEvents.clear();
+        sassCompiler.addSilenceDeprecation("global-builtin");
+        assertDoesNotThrow(() -> sassCompiler.compileString(string, OutputStyle.EXPANDED));
+        assertThat(logEvents).noneMatch(event -> event.getType() == LogEventType.DEPRECATION_WARNING);
+    }
+
+    @Test
+    void fatalDeprecations() {
+        @Language("SCSS") String scss = ".foo { color: adjust-color(#000000, $red: 255); }";
+        
+        InboundMessage.CompileRequest.StringInput string = InboundMessage.CompileRequest.StringInput.newBuilder()
+                .setSource(scss)
+                .build();
+        
+        sassCompiler.addFatalDeprecation("global-builtin");
+        SassCompilationFailedException ex = assertThrows(SassCompilationFailedException.class, () -> {
+            sassCompiler.compileString(string, OutputStyle.EXPANDED);
+        });
+        assertThat(ex.getMessage()).contains("deprecat");
+    }
 }


### PR DESCRIPTION
This PR adds support for the Sass Deprecation API.

It's inherently difficult to add test cases for this API as the test cases might break as soon as the deprecated feature gets removed.
Even though, I've added test cases for `fatalDeprecations` and `silenceDeprecations` based on the deprecation `global-builtin`, scheduled to be removed in dart-sass 3.0. As of now, there are no `futureDeprecations` so testing those seems impossible.