### PR TITLE
Fix re-extraction of partially cleaned dart-sass cache

### DIFF
--- a/sass-embedded-host/src/main/java/de/larsgrefer/sass/embedded/connection/DartSassPackageProvider.java
+++ b/sass-embedded-host/src/main/java/de/larsgrefer/sass/embedded/connection/DartSassPackageProvider.java
@@ -46,19 +46,33 @@ public abstract class DartSassPackageProvider {
         }
 
         File execDir = targetPath.resolve("dart-sass").toFile();
+        File result = findExecutable(execDir);
 
-        File[] execFile = execDir.listFiles(pathname -> pathname.isFile() && pathname.getName().startsWith("sass"));
+        if (result == null && !IOUtils.isEmpty(targetPath)) {
+            log.info("No unique dart-sass executable found in {}, extracting {} again", execDir, dist);
+            try {
+                IOUtils.extract(dist, targetPath);
+            } catch (IOException e) {
+                throw new IOException(String.format("Failed to extract %s into %s", dist, targetPath), e);
+            }
+            result = findExecutable(execDir);
+        }
 
-        File result;
-
-        if (execFile == null || execFile.length != 1) {
+        if (result == null) {
             throw new IllegalStateException("No (unique) executable file found in " + execDir);
-        } else {
-            result = execFile[0];
         }
 
         result.setExecutable(true, true);
         return result;
+    }
+
+    private File findExecutable(File execDir) {
+        File[] execFile = execDir.listFiles(pathname -> pathname.isFile() && pathname.getName().startsWith("sass"));
+        if (execFile == null || execFile.length != 1) {
+            return null;
+        }
+
+        return execFile[0];
     }
 
     Path getTargetPath() throws IOException {

--- a/sass-embedded-host/src/test/java/de/larsgrefer/sass/embedded/connection/DartSassPackageProviderTest.java
+++ b/sass-embedded-host/src/test/java/de/larsgrefer/sass/embedded/connection/DartSassPackageProviderTest.java
@@ -4,8 +4,17 @@ import de.larsgrefer.sass.embedded.SassCompiler;
 import de.larsgrefer.sass.embedded.SassCompilerFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.OutputStream;
 import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,5 +41,56 @@ class DartSassPackageProviderTest {
             assertThat(compiler.getVersion()).isNotNull();
         }
 
+    }
+
+    @Test
+    void extractPackageRestoresMissingExecutable(@TempDir Path tempDir) throws IOException {
+        Path archive = tempDir.resolve("dart-sass.zip");
+        createDartSassZip(archive);
+
+        Path targetPath = tempDir.resolve("target");
+        DartSassPackageProvider provider = new TestPackageProvider(archive.toUri().toURL(), targetPath);
+
+        File executable = provider.extractPackage();
+        assertThat(executable).isFile();
+
+        Files.delete(executable.toPath());
+        Files.write(targetPath.resolve("dart-sass").resolve("kept-by-temp-cleaner"), new byte[0]);
+
+        File restoredExecutable = provider.extractPackage();
+        assertThat(restoredExecutable).isFile();
+    }
+
+    private void createDartSassZip(Path archive) throws IOException {
+        try (OutputStream outputStream = Files.newOutputStream(archive);
+             ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            zipOutputStream.putNextEntry(new ZipEntry("dart-sass/"));
+            zipOutputStream.closeEntry();
+            zipOutputStream.putNextEntry(new ZipEntry("dart-sass/sass"));
+            zipOutputStream.write(new byte[]{1});
+            zipOutputStream.closeEntry();
+        }
+    }
+
+    private static class TestPackageProvider extends DartSassPackageProvider {
+
+        private final URL packageUrl;
+        private final Path targetPath;
+
+        TestPackageProvider(URL packageUrl, Path targetPath) {
+            this.packageUrl = packageUrl;
+            this.targetPath = targetPath;
+        }
+
+        @Override
+        Path getTargetPath() {
+            return targetPath;
+        }
+
+        @Nullable
+        @Override
+        protected URL getPackageUrl() {
+            return packageUrl;
+        }
     }
 }


### PR DESCRIPTION
This issue is that on my mac, after about a week the system cleans up the data in the /tmp folder where the dart executable is stored and throws the following error.

```
Caused by: java.lang.IllegalStateException: No (unique) executable file found in /var/folders/n7/yh5g35d11fngspgm_mmplzsc0000gn/T/de.larsgrefer.sass.embedded.bundled/3.0.0-SNAPSHOT/dart-sass/3.0.0-SNAPSHOT/dart-sass
```

The bundled package provider previously skipped extraction whenever the target temp directory contained any regular file. If an OS temp cleaner removed the dart-sass/sass executable but left the cache directory or other files behind, startup failed with “No (unique) executable file found”.

Validate the extracted executable before returning it, and re-extract the archive when the cache is non-empty but the executable is missing or ambiguous. Add a regression test for the partial-cache-cleanup case.